### PR TITLE
feat(publish): validate atoms against ekala.toml manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
  "toml_edit 0.23.5",
  "tracing",
  "tracing-indicatif",
+ "tracing-subscriber",
  "unicode-ident",
  "unicode-normalization",
  "url",

--- a/crates/atom/Cargo.toml
+++ b/crates/atom/Cargo.toml
@@ -44,6 +44,7 @@ snix-store = { git = "https://github.com/nrdxp/snix", branch = "canon", default-
 ] }
 
 [dev-dependencies]
-anyhow.workspace   = true
-insta.workspace    = true
-tempfile.workspace = true
+anyhow.workspace             = true
+insta.workspace              = true
+tempfile.workspace           = true
+tracing-subscriber.workspace = true

--- a/crates/atom/src/package/metadata/mod.rs
+++ b/crates/atom/src/package/metadata/mod.rs
@@ -587,7 +587,7 @@ impl MetaData {
 impl<'a, S: LocalStorage> EkalaManager<'a, S> {
     /// Create a new manifest writer, traversing upward to locate the nearest ekala.toml if
     /// necessary.
-    pub fn new(storage: &'a S) -> Result<Self, AtomError> {
+    pub fn open(storage: &'a S) -> Result<Self, AtomError> {
         let path = storage
             .ekala_root_dir()
             .map_err(|e| {
@@ -613,6 +613,11 @@ impl<'a, S: LocalStorage> EkalaManager<'a, S> {
             manifest,
             storage,
         })
+    }
+
+    /// return `AtomMap` structure from the contained Ekala manifest
+    pub fn atoms(&self) -> &AtomMap {
+        self.manifest.set().packages()
     }
 
     /// writes a new, minimal atom.toml to path, and updates the ekala.toml manifest

--- a/crates/atom/src/package/publish/error.rs
+++ b/crates/atom/src/package/publish/error.rs
@@ -80,12 +80,15 @@ pub mod git {
         /// The path given does not point to an Atom.
         #[error("The given path does not point to an Atom")]
         NotAnAtom(PathBuf),
-        /// No Atoms were found under the given directory.
-        #[error("Failed to find any Atoms under the current directory")]
+        /// No Atoms were found in the manifest which can be published.
+        #[error("Failed to find any publishable atoms")]
         NotFound,
         /// The remote is not initialized as an Ekala store.
         #[error("Remote is not initialized")]
         NotInitialized,
+        /// The remote is not initialized as an Ekala store.
+        #[error("Repository is not initialized at requested revision")]
+        NotLocallyInitialized,
         /// Failed to update a git reference.
         #[error(transparent)]
         RefUpdateFailed(#[from] gix::reference::edit::Error),
@@ -107,6 +110,9 @@ pub mod git {
         /// Failed to write a git object.
         #[error(transparent)]
         WriteFailed(#[from] object::write::Error),
+        /// Failed to deserialize
+        #[error(transparent)]
+        Deserialize(#[from] toml_edit::de::Error),
     }
 
     //================================================================================================

--- a/crates/atom/src/package/publish/git/inner.rs
+++ b/crates/atom/src/package/publish/git/inner.rs
@@ -310,7 +310,7 @@ impl<'a> GitContext<'a> {
 //================================================================================================
 
 /// Reads the full content of a Git blob object into a specified output format.
-fn read_blob<F, R>(obj: &Object, mut f: F) -> GitResult<R>
+pub(super) fn read_blob<F, R>(obj: &Object, mut f: F) -> GitResult<R>
 where
     F: FnMut(&mut dyn Read) -> io::Result<R>,
 {

--- a/crates/atom/src/package/sets/mod.rs
+++ b/crates/atom/src/package/sets/mod.rs
@@ -92,7 +92,7 @@ impl<'a, 'b, S: LocalStorage> SetResolver<'a, 'b, S> {
     /// Creates a new `SetResolver` to validate the package sets in a manifest.
     pub(super) fn new(storage: &'a S, manifest: &'b Manifest) -> Result<Self, AtomError> {
         let len = manifest.package().sets().len();
-        let ekala = EkalaManager::new(storage)?;
+        let ekala = EkalaManager::open(storage)?;
         Ok(Self {
             manifest,
             ekala,

--- a/src/cli/commands/new/mod.rs
+++ b/src/cli/commands/new/mod.rs
@@ -42,7 +42,7 @@ pub(super) async fn run(storage: &impl LocalStorage, args: Args) -> Result<()> {
         args.path.file_name().unwrap_or(OsStr::new("")).try_into()?
     };
 
-    let mut manager = EkalaManager::new(storage)?;
+    let mut manager = EkalaManager::open(storage)?;
 
     manager
         .new_atom_at_path(label, args.path, args.version)


### PR DESCRIPTION
### Description

feat(publish): validate atoms against ekala.toml manifest

- Ensure only atoms present in ekala.toml at publish commit are published
- Refactor StateValidator to read manifest instead of traversing tree
- Rename EkalaManager::new to ::open and add atoms() method
- Add tracing-subscriber dependency for test logging
- Fix broken test after validation changes

### Checklist

- [x] I have read the [**Contributing Guide**](CONTRIBUTING.md).
- [x] I have followed the [**Style Guide**](STYLE_GUIDE.md).
- [x] I have added tests that prove my fix is effective or that my feature works.