### PR TITLE
Doc/fix incorrect docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Key modules include:
 - `atom::uri` - URI parsing and resolution
 - `atom::storage` - Storage backend implementations
 
-See the [atom crate documentation](https://docs.rs/atom) for detailed API information.
+See the [atom crate documentation](https://docs.eka.rs/atom/) for detailed API information.
 
 ### CLI Interface
 

--- a/crates/atom/src/lib.rs
+++ b/crates/atom/src/lib.rs
@@ -89,15 +89,15 @@ const EKALA: &str = "ekala";
 const LOCK: &str = "lock";
 const TOML: &str = "toml";
 
-/// The conventional filename for an Atom lockfile (e.g., `atom.lock`).
-///
-/// This static variable is lazily initialized to ensure it is constructed only when needed.
-pub static ATOM_MANIFEST_NAME: LazyLock<String> = LazyLock::new(|| format!("{}.{}", ATOM, TOML));
 /// The conventional filename for an Atom manifest (e.g., `atom.toml`).
 ///
 /// This static variable is lazily initialized to ensure it is constructed only when needed.
-pub static EKALA_MANIFEST_NAME: LazyLock<String> = LazyLock::new(|| format!("{}.{}", EKALA, TOML));
+pub static ATOM_MANIFEST_NAME: LazyLock<String> = LazyLock::new(|| format!("{}.{}", ATOM, TOML));
 /// The conventional filename for an Ekala manifest (e.g., `ekala.toml`).
+///
+/// This static variable is lazily initialized to ensure it is constructed only when needed.
+pub static EKALA_MANIFEST_NAME: LazyLock<String> = LazyLock::new(|| format!("{}.{}", EKALA, TOML));
+/// The conventional filename for an Atom lockfile (e.g., `atom.lock`).
 ///
 /// This static variable is lazily initialized to ensure it is constructed only when needed.
 pub static LOCK_NAME: LazyLock<String> = LazyLock::new(|| format!("{}.{}", ATOM, LOCK));


### PR DESCRIPTION
### Description

- Reordered documentation for the `atom` static variables, to make sure that they refer to the correct item. 
- Corrected a link that was incorrectly pointing to the wrong `atom` crate.

### Related Issue

N/A

### Checklist

- [x] I have read the [**Contributing Guide**](CONTRIBUTING.md).
- [x] I have followed the [**Style Guide**](STYLE_GUIDE.md).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation with the relevant changes.
